### PR TITLE
Add allowFontScaling & fontSize props for Skip, Next, and Done labels

### DIFF
--- a/AppIntro.js
+++ b/AppIntro.js
@@ -409,5 +409,6 @@ AppIntro.defaultProps = {
   showSkipButton: true,
   showDoneButton: true,
   showDots: true
-  allowFontScaling: true
+  allowFontScaling: true,
+  fontSize: 22
 };

--- a/AppIntro.js
+++ b/AppIntro.js
@@ -19,7 +19,7 @@ import RenderDots from './components/Dots';
 const windowsWidth = Dimensions.get('window').width;
 const windowsHeight = Dimensions.get('window').height;
 
-const defaulStyles = {
+const defaultStyles = {
   header: {
     flex: 0.5,
     justifyContent: 'center',
@@ -108,7 +108,7 @@ export default class AppIntro extends Component {
   constructor(props) {
     super(props);
 
-    this.styles = StyleSheet.create(assign({}, defaulStyles, props.customStyles));
+    this.styles = StyleSheet.create(assign({}, defaultStyles, props.customStyles));
 
     this.state = {
       skipFadeOpacity: new Animated.Value(1),
@@ -388,6 +388,8 @@ AppIntro.propTypes = {
   showSkipButton: PropTypes.bool,
   showDoneButton: PropTypes.bool,
   showDots: PropTypes.bool,
+  allowFontScaling: PropTypes.bool,
+  fontSize: PropTypes.number
 };
 
 AppIntro.defaultProps = {
@@ -407,4 +409,5 @@ AppIntro.defaultProps = {
   showSkipButton: true,
   showDoneButton: true,
   showDots: true
+  allowFontScaling: true
 };

--- a/README.md
+++ b/README.md
@@ -179,7 +179,6 @@ And in Android, image inside view component, view need width、height.
 | showSkipButton | bool | true | a boolean defining if we should render the skip button |
 | showDoneButton | bool | true | a boolean that defines if we should render the done button |
 | showDots | bool | true | a boolean that defines if we should render the bottom dots |
-
 | allowFontScaling | bool | true | a boolean that defines if we should allow font scaling on devices with larger text sizes enabled |
 | fontSize | number | 22 | a number that specifies the size of the Skip, Done, and Next labels |
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ And in Android, image inside view component, view need width、height.
 | showDoneButton | bool | true | a boolean that defines if we should render the done button |
 | showDots | bool | true | a boolean that defines if we should render the bottom dots |
 
+| allowFontScaling | bool | true | a boolean that defines if we should allow font scaling on devices with larger text sizes enabled |
+| fontSize | number | 22 | a number that specifies the size of the Skip, Done, and Next labels |
+
 ##### **Children View Properties**
 | Prop  | PropType | Default Value | Description           |
 |-------|----------|---------------|-----------------------|

--- a/components/DoneButton.android.js
+++ b/components/DoneButton.android.js
@@ -9,13 +9,14 @@ export const DoneButton = ({
   styles, onDoneBtnClick, onNextBtnClick,
   rightTextColor, isDoneBtnShow,
   doneBtnLabel, nextBtnLabel,
+  allowFontScaling, fontSize
 }) => {
   return (
     <View style={[styles.btnContainer, { height: 0, paddingBottom: 5 }]}>
       <TouchableOpacity style={styles.full}
         onPress={ isDoneBtnShow ? onDoneBtnClick : onNextBtnClick}
       >
-       <Text style={[styles.nextButtonText, { color: rightTextColor }]}>
+       <Text allowFontScaling={allowFontScaling} style={[styles.nextButtonText, { color: rightTextColor, fontSize }]}>
          {isDoneBtnShow ? doneBtnLabel : nextBtnLabel}
        </Text>
       </TouchableOpacity>

--- a/components/DoneButton.ios.js
+++ b/components/DoneButton.ios.js
@@ -10,7 +10,8 @@ export const DoneButton = ({
   styles, onDoneBtnClick, onNextBtnClick,
   rightTextColor, isDoneBtnShow,
   doneBtnLabel, nextBtnLabel,
-  doneFadeOpacity, skipFadeOpacity, nextOpacity
+  doneFadeOpacity, skipFadeOpacity, nextOpacity,
+  allowFontScaling, fontSize
 }) => {
   return (
     <View style={styles.btnContainer}>
@@ -25,8 +26,8 @@ export const DoneButton = ({
       }]}
       >
         <View style={styles.full}>
-          <Text style={[styles.controllText, {
-            color: rightTextColor, paddingRight: 30,
+          <Text allowFontScaling={allowFontScaling} style={[styles.controllText, {
+            color: rightTextColor, paddingRight: 30, fontSize
           }]}>
             {doneBtnLabel}
           </Text>
@@ -35,7 +36,7 @@ export const DoneButton = ({
       <Animated.View style={[styles.full, { height: 0 }, { opacity: nextOpacity }]}>
         <TouchableOpacity style={styles.full}
           onPress={ isDoneBtnShow ? onDoneBtnClick : onNextBtnClick}>
-         <Text style={[styles.nextButtonText, { color: rightTextColor }]}>
+         <Text allowFontScaling={allowFontScaling} style={[styles.nextButtonText, { color: rightTextColor, fontSize }]}>
           {nextBtnLabel}
         </Text>
         </TouchableOpacity>
@@ -45,4 +46,3 @@ export const DoneButton = ({
 }
 
 export default DoneButton
-        

--- a/components/SkipButton.android.js
+++ b/components/SkipButton.android.js
@@ -10,7 +10,9 @@ export const SkipButton = ({
   styles, onSkipBtnClick, isSkipBtnShow,
   leftTextColor,
   skipBtnLabel,
-  skipFadeOpacity
+  skipFadeOpacity,
+  allowFontScaling,
+  fontSize
 }) => {
   return (
     <View style={[styles.btnContainer, {
@@ -20,7 +22,7 @@ export const SkipButton = ({
       <TouchableOpacity
         style={styles.full}
         onPress={isSkipBtnShow ? () => onSkipBtnClick() : null}>
-        <Text style={[styles.controllText, { color: leftTextColor }]}>
+        <Text allowFontScaling={allowFontScaling} style={[styles.controllText, { color: leftTextColor, fontSize }]}>
           {skipBtnLabel}
         </Text>
       </TouchableOpacity>

--- a/components/SkipButton.ios.js
+++ b/components/SkipButton.ios.js
@@ -10,7 +10,8 @@ export const SkipButton = ({
   styles, onSkipBtnClick, isSkipBtnShow,
   leftTextColor,
   skipBtnLabel,
-  skipFadeOpacity
+  skipFadeOpacity,
+  allowFontScaling, fontSize
 }) => {
   return (
     <Animated.View style={[styles.btnContainer, {
@@ -26,7 +27,7 @@ export const SkipButton = ({
       <TouchableOpacity
         style={styles.full}
         onPress={isSkipBtnShow ? () => onSkipBtnClick() : null}>
-        <Text style={[styles.controllText, { color: leftTextColor }]}>
+        <Text allowFontScaling={allowFontScaling} style={[styles.controllText, { color: leftTextColor, fontSize }]}>
           {skipBtnLabel}
         </Text>
       </TouchableOpacity>


### PR DESCRIPTION
I came across an issue with the Skip & Done labels for devices that have larger font sizes enabled.

Added 2 props:
* `allowFontScaling` prop to disable font scaling as an option (it is `true` by default).
* `fontSize` to allow setting of the size of the labels

Updated README



(Also fixed what I thought was a typo in AppIntro.js - defaultStyles instead of defaulStyles)