### PR TITLE
Remove Arial fontFamily to avoid errors with Expo.io

### DIFF
--- a/AppIntro.js
+++ b/AppIntro.js
@@ -94,7 +94,7 @@ const defaulStyles = {
   nextButtonText: {
     fontSize: 25,
     fontWeight: 'bold',
-    fontFamily: 'Arial',
+    //fontFamily: 'Arial',
   },
   full: {
     height: 80,


### PR DESCRIPTION
Who uses Expo.io will see an annoying error related with fontFamily Arial.

But, this fontFamily is only applied to the next button as an arrow. So, this PR goal is to remove Arial fontFamily because:

- Arial fontFamily is not available in all vendor platform
- And is only used in a small part of the module