### PR TITLE
Changed from deprecated PropTypes to prop-types package to support React 16.0.0

### DIFF
--- a/AppIntro.js
+++ b/AppIntro.js
@@ -1,5 +1,6 @@
 import assign from 'assign-deep';
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 import {
   StatusBar,
   StyleSheet,

--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
   "homepage": "https://github.com/fuyaode/react-native-app-intro#readme",
   "dependencies": {
     "assign-deep": "^0.4.5",
-    "react-native-swiper": "git+https://github.com/FuYaoDe/react-native-swiper.git"
-  },
-  "peerDependencies": {
+    "react-native-swiper": "git+https://github.com/FuYaoDe/react-native-swiper.git",
     "prop-types": "^15.5.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
   "dependencies": {
     "assign-deep": "^0.4.5",
     "react-native-swiper": "git+https://github.com/FuYaoDe/react-native-swiper.git"
+  },
+  "peerDependencies": {
+    "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
Hello,

I changed so this package have a dependency on the "prop-types" package instead of getting the PropTypes from React. It is deprecated since a while back and PropTypes is removed in the full version for React 16.

Please accept this PR. Thanks!