### PR TITLE
Fixed wrong use of styles in DoneButton.js

### DIFF
--- a/components/DoneButton.android.js
+++ b/components/DoneButton.android.js
@@ -15,7 +15,7 @@ export const DoneButton = ({
       <TouchableOpacity style={styles.full}
         onPress={ isDoneBtnShow ? onDoneBtnClick : onNextBtnClick}
       >
-       <Text style={[styles.nextButtonText, { color: rightTextColor }]}>
+       <Text style={[styles.controllText, { color: rightTextColor }]}>
          {isDoneBtnShow ? doneBtnLabel : nextBtnLabel}
        </Text>
       </TouchableOpacity>


### PR DESCRIPTION
By using the custom styles, I found an error:
In file ./components/DoneButton.android.js (line 18), the **nextButtonText** style was used for the style of the text of the 'Done' button, instead of the **controllText** style.

`<Text style={[styles.nextButtonText, { color: rightTextColor }]}>`

has to be replaced with 

`<Text style={[styles.controllText, { color: rightTextColor }]}>`